### PR TITLE
PHP 7.2 / SilverStripe 3.7.x Support

### DIFF
--- a/_config.php
+++ b/_config.php
@@ -1,0 +1,5 @@
+<?php
+
+// Ensure compatibility with PHP 7.2 ("object" is a reserved word),
+// with SilverStripe 3.6 (using Object) and SilverStripe 3.7 (using SS_Object)
+if (!class_exists('SS_Object')) class_alias('Object', 'SS_Object');

--- a/code/Populate.php
+++ b/code/Populate.php
@@ -3,8 +3,8 @@
 /**
  * @package populate
  */
-class Populate extends Object {
-		
+class Populate extends SS_Object {
+
 	/**
 	 * @config
 	 *
@@ -89,7 +89,7 @@ class Populate extends Object {
 
 			$fixture = null;
 		}
-			
+
 		// hook allowing extensions to clean up records, modify the result or
 		// export the data to a SQL file (for importing performance).
 		$static = !(isset($this) && get_class($this) == __CLASS__);
@@ -119,7 +119,7 @@ class Populate extends Object {
 
 	private static function truncate_versions($table, $versions) {
 		self::truncate_table($table .'_versions');
-		
+
 		foreach($versions as $stage => $v) {
 			self::truncate_table($table . '_'. $stage);
 		}


### PR DESCRIPTION
Small changes to support PHP 7.2 as per the official upgrade guide: https://docs.silverstripe.org/en/3/changelogs/3.7.0/#silverstripe-3-7-and-php-7-2-and-object-subclasses