### PR TITLE
MNT Update PHP versions for testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,19 +5,13 @@ import:
 
 jobs:
   include:
-    - php: 7.1
-      env:
-        - DB=MYSQL
-        - REQUIRE_INSTALLER="4.x-dev"
-        - PHPUNIT_COVERAGE_TEST=1
-        - PHPCS_TEST=1
-    - php: 7.3
-      env:
-        - DB=MYSQL
-        - REQUIRE_INSTALLER="4.x-dev"
-        - PHPUNIT_COVERAGE_TEST=1
     - php: 7.4
       env:
         - DB=MYSQL
         - REQUIRE_INSTALLER="4.x-dev"
         - PHPUNIT_COVERAGE_TEST=1
+    - php: 8.0
+      env:
+        - DB=MYSQL
+        - REQUIRE_INSTALLER="4.x-dev"
+        - PHPCS_TEST=1


### PR DESCRIPTION
PHP versions < 7.4 are no longer supported by silverstripe framework.