### PR TITLE
Bugfix - Prevents error when property is not defined

### DIFF
--- a/code/Populate.php
+++ b/code/Populate.php
@@ -39,7 +39,7 @@ class Populate
      *
      * @var array
      */
-    private static $truncate_classes = [];
+    private static $truncate_objects = [];
 
     /**
      * @config


### PR DESCRIPTION
This property name was changed in a [previous commit](https://github.com/silverstripe/silverstripe-populate/commit/cdf58a51b7c537e6682d4130457972cb1078204f) w/o changing the references to it in other sections of the code.

The mismatch results in an error if the `$truncate_objects` value is not set in a config yml.

Whether or not the name change makes sense, this is a breaking change that would require a major version bump so I think it should be reverted to the original.

Fixes #42 