### PR TITLE
Allows PopulateMergeMatch to run with Images

### DIFF
--- a/code/PopulateFactory.php
+++ b/code/PopulateFactory.php
@@ -248,7 +248,7 @@ class PopulateFactory extends FixtureFactory
             $hash = $existingObj->File->getHash();
 
             if (hash_equals($hash, sha1(file_get_contents($fixtureFilePath)))) {
-                return true;
+                return $file;
             }
         } else {
             // Create instance of file data object based on the extension of the fixture file


### PR DESCRIPTION
Fixes #45

I don't know this library well enough to conclusively say that no other piece of code is expecting a boolean instead of an object, but this makes sense to me and it has fixed the issue I was having.