### PR TITLE
fix: correct $segment for PopulateTask per docs

### DIFF
--- a/code/PopulateTask.php
+++ b/code/PopulateTask.php
@@ -11,6 +11,8 @@ use SilverStripe\Dev\BuildTask;
  */
 class PopulateTask extends BuildTask
 {
+    private static $segment = 'PopulateTask';
+        
     /**
      * @param HTTPRequest $request
      * @throws Exception


### PR DESCRIPTION
@GuySartorelli as per https://github.com/silverstripe/silverstripe-staticpublishqueue/commit/2f05ec1ec3ca0837b258564dc30034676f2d67d1 it looks like this class was upgraded without one defined but the documentation refers to the old version. To review if we should mark this as a API change before merge. I don't think this would be as drastic as the above one since it's unlikely anyones running it in production (only perhaps for demo sites)