### PR TITLE
Updating to work with SSv6

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ objects can be defined in YAML and shared around developers. This extends the
 ## Requirements
 
 * PHP 8.1
-* SilverStripe [Framework ^5](https://github.com/silverstripe/silverstripe-framework)
-* SilverStripe [Versioned ^2](https://github.com/silverstripe/silverstripe-versioned)
+* SilverStripe [Framework ^6](https://github.com/silverstripe/silverstripe-framework)
+* SilverStripe [Versioned ^3](https://github.com/silverstripe/silverstripe-versioned)
 
 ## Installation Instructions
 

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ objects can be defined in YAML and shared around developers. This extends the
 
 ## Requirements
 
-* PHP 8.1
+* PHP 8.3
 * SilverStripe [Framework ^6](https://github.com/silverstripe/silverstripe-framework)
 * SilverStripe [Versioned ^3](https://github.com/silverstripe/silverstripe-versioned)
 

--- a/code/PopulateTask.php
+++ b/code/PopulateTask.php
@@ -3,19 +3,22 @@
 namespace DNADesign\Populate;
 
 use Exception;
-use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Dev\BuildTask;
+use SilverStripe\PolyExecution\PolyOutput;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
 
 class PopulateTask extends BuildTask
 {
-    private static string $segment = 'PopulateTask';
+    protected static string $commandName = 'PopulateTask';
 
     /**
-     * @param HTTPRequest $request
      * @throws Exception
      */
-    public function run($request)
+    protected function execute(InputInterface $input, PolyOutput $output): int
     {
         Populate::requireRecords();
+
+        return Command::SUCCESS;
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
         "email": "will@fullscreen.io"
     }],
     "require": {
-        "php": "^8.1",
+        "php": "^8.3",
         "silverstripe/framework": "^6.0",
         "silverstripe/versioned": "^3.0"
     },
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "3.0.x-dev"
+            "dev-master": "4.0.x-dev"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
     }],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "^5",
-        "silverstripe/versioned": "^2"
+        "silverstripe/framework": "~6.0.0@beta",
+        "silverstripe/versioned": "~3.0.0@beta"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "^3",
+        "silverstripe/recipe-testing": "4.x-dev",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -10,11 +10,11 @@
     }],
     "require": {
         "php": "^8.1",
-        "silverstripe/framework": "~6.0.0@beta",
-        "silverstripe/versioned": "~3.0.0@beta"
+        "silverstripe/framework": "^6.0",
+        "silverstripe/versioned": "^3.0"
     },
     "require-dev": {
-        "silverstripe/recipe-testing": "4.x-dev",
+        "silverstripe/recipe-testing": "^4.0",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "autoload": {
@@ -26,7 +26,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "2.0.x-dev"
+            "dev-master": "3.0.x-dev"
         }
     },
     "config": {


### PR DESCRIPTION
## Description

This PR adds support for Silverstripe 6.

- Updated PHP to be 8.3
- Increased the version of silverstripe/versioned
- Increased the version of silverstripe/framework
- Updated the `PopulateTask` to be compatible with the changes on `BuildTask`

## Manual testing steps

- Test the tasks on URL with `dev/tasks/PopulateTask/`
- Using dev/tasks select `DNADesign\Populate\PopulateTask`

## Pull request checklist
- [x] The target branch is correct
- [x] All commits are relevant to the purpose of the PR (e.g. no debug statements, unrelated refactoring, or arbitrary linting)
    - Small amounts of additional linting are usually okay, but if it makes it hard to concentrate on the relevant changes, ask for the unrelated changes to be reverted, and submitted as a separate PR.
- [x] The commit messages follow our [commit message guidelines](https://docs.silverstripe.org/en/contributing/code/#commit-messages)
- [x] The PR follows our [contribution guidelines](https://docs.silverstripe.org/en/contributing/code/)
- [x] Code changes follow our [coding conventions](https://docs.silverstripe.org/en/contributing/coding_conventions/)
- [x] This change is covered with tests (or tests aren't necessary for this change)
- [x] Any relevant User Help/Developer documentation is updated; for impactful changes, information is added to the changelog for the intended release
- [x] CI is green
