### PR TITLE
fix: return File object instead of bool from populateFile()

### DIFF
--- a/code/PopulateFactory.php
+++ b/code/PopulateFactory.php
@@ -225,10 +225,10 @@ class PopulateFactory extends FixtureFactory
 
     /**
      * @param array $data
-     * @return File|bool The created (or updated) File object, or true if the file already existed
+     * @return File The created, updated, or existing File object
      * @throws Exception If anything is missing and the file can't be processed
      */
-    private function populateFile(array $data): File|bool
+    private function populateFile(array $data): File
     {
         if (!isset($data['Filename']) || !isset($data['PopulateFileFrom'])) {
             throw new Exception('When passing "PopulateFileFrom", you must also pass "Filename" with the path that you want to file to be stored at (e.g. assets/test.jpg)');
@@ -248,7 +248,7 @@ class PopulateFactory extends FixtureFactory
             $hash = $existingObj->File->getHash();
 
             if (hash_equals($hash, sha1(file_get_contents($fixtureFilePath) ?? ''))) {
-                return true;
+                return $existingObj;
             }
         } else {
             // Create instance of file data object based on the extension of the fixture file
@@ -285,8 +285,9 @@ class PopulateFactory extends FixtureFactory
             $file->write();
             $file->publishRecursive();
         } catch (Exception $e) {
-            throw $e;
             DB::alteration_message($e->getMessage(), "error");
+
+            throw $e;
         }
 
         return $file;


### PR DESCRIPTION
## Problem

`populateFile()` returns `true` (boolean) when an existing file's content hash matches the fixture source file. However, `createObject()` unconditionally accesses `$file->ID` on the return value at line 71:

```php
$this->fixtures[$name][$identifier] = $file->ID;
```

This causes two issues on subsequent PopulateTask runs:

1. **PHP Warning**: `Attempt to read property "ID" on true` — emitted for every unchanged file fixture
2. **Fatal InvalidArgumentException**: Since the fixture ID is never registered in the `$fixtures` map, any downstream fixture that references the file (e.g. `=>SilverStripe\Assets\Image.myImage`) fails with `No fixture definitions found for "=>SilverStripe\Assets\Image.myImage"`

The second issue is particularly disruptive because it crashes the entire populate run, preventing later fixtures from being created.

## Root Cause

In `populateFile()` at line 250-251:

```php
if (hash_equals($hash, sha1(file_get_contents($fixtureFilePath) ?? ''))) {
    return true;  // BUG: should return the existing File object
}
```

The existing `$existingObj` is already available and verified — returning it instead of `true` is the correct behavior.

## Fix

1. **Return `$existingObj` instead of `true`** when the file hash matches — the File object is already loaded and verified
2. **Update return type** from `File|bool` to `File` since all code paths now return a File object
3. **Fix unreachable code** in the catch block where `throw` preceded the error log `DB::alteration_message()` call

## Testing

Verified by running `ddev sake dev/tasks/PopulateTask` on a project with 20+ image fixtures:
- **Before**: Fatal crash at first `StaffMember` referencing a team image
- **After**: Clean run, all fixtures created, no warnings